### PR TITLE
Fix import paths in endpoints

### DIFF
--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -1,7 +1,7 @@
 import os
 from fastapi import APIRouter, UploadFile, File
-from ....core.grpc_client import grpc_client_manager
-from ....core.config import settings
+from ...core.grpc_client import grpc_client_manager
+from ...core.config import settings
 
 router = APIRouter()
 

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
-from ....core.config import settings
-from ....core.grpc_client import grpc_client_manager
+from ...core.config import settings
+from ...core.grpc_client import grpc_client_manager
 import json
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- fix relative imports in chat and admin endpoints

## Testing
- `python -m py_compile backend/app/api/endpoints/chat.py backend/app/api/endpoints/admin.py`
- `docker-compose build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ac14dca4832889c75ead455aad35