### PR TITLE
Add Dockerignore files

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore version control
+.git
+.gitignore
+
+# Python caches and compiled files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+.venv/
+env/
+
+# Environment files
+.env
+*.env
+
+# Logs and temporary files
+*.log
+*.tmp
+*.swp
+
+# Local data and models
+data/
+models/

--- a/frontend-admin/.dockerignore
+++ b/frontend-admin/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore version control
+.git
+.gitignore
+
+# Node modules and build output
+node_modules/
+dist/
+
+# Environment files
+.env
+*.env
+
+# Logs and temp files
+npm-debug.log*
+*.log
+*.tmp
+*.swp
+
+# Local data and models
+data/
+models/

--- a/frontend-user/.dockerignore
+++ b/frontend-user/.dockerignore
@@ -1,0 +1,21 @@
+# Ignore version control
+.git
+.gitignore
+
+# Node modules and build output
+node_modules/
+dist/
+
+# Environment files
+.env
+*.env
+
+# Logs and temp files
+npm-debug.log*
+*.log
+*.tmp
+*.swp
+
+# Local data and models
+data/
+models/

--- a/inference/.dockerignore
+++ b/inference/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore version control
+.git
+.gitignore
+
+# Python caches and compiled files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+.venv/
+env/
+
+# Environment files
+.env
+*.env
+
+# Logs and temporary files
+*.log
+*.tmp
+*.swp
+
+# Local data and models
+data/
+models/


### PR DESCRIPTION
## Summary
- add `.dockerignore` files for backend, inference, and frontends
- ignore git metadata, caches, env files, logs and local data/models during Docker build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ad92a67483288586516050e725d3