### PR TITLE
Fix settings import for pydantic v2

### DIFF
--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from typing import List
 
 class Settings(BaseSettings):


### PR DESCRIPTION
## Summary
- update backend settings module to use `pydantic_settings.BaseSettings`

## Testing
- `pytest -q`
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6857b123473083288d3a2b6b062e4ac2