### PR TITLE
Fix RAG service recursion

### DIFF
--- a/backend/app/services/rag_service.py
+++ b/backend/app/services/rag_service.py
@@ -1,13 +1,13 @@
 import os
 from typing import List, Dict, Optional
-from .model_service import RAGService
+from .model_service import RAGService as ModelService
 
 # 假定知识库文档简单保存在文本文件，或后续可对接 ChromaDB
 KNOWLEDGE_DIR = "/data/knowledge"   # 文档存放路径
 
 class RAGService:
     def __init__(self, model_dir: str, knowledge_dir: Optional[str] = None):
-        self.model_service = RAGService(model_dir)
+        self.model_service = ModelService(model_dir)
         self.knowledge_dir = knowledge_dir or KNOWLEDGE_DIR
 
     def _load_knowledge_texts(self) -> List[str]:


### PR DESCRIPTION
## Summary
- alias the imported RAGService from model_service as `ModelService`
- use `ModelService` when creating the model service instance

## Testing
- `python -m py_compile backend/app/services/rag_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6857b1253f248328a250e8de4ddccd9f