### PR TITLE
Add schema for model switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,18 @@ The inference service looks for generation and embedding models inside the `mode
 Embedding models can be placed under `models/embedding-model/`. A list of URLs for an example embedding model is provided in `models/urls.txt`. Download the files to that folder if you want to enable embedding retrieval. When the inference service starts it will automatically load the first generation and embedding models it discovers.
 
 Once the files are in place you can visit `http://localhost:8081/model-management` to switch or upload models.
+
+### Switching Models via API
+
+The backend exposes a `POST /api/admin/models/switch` endpoint. The request body
+must be JSON in the following form:
+
+```json
+{
+  "model_name": "your-model-file.gguf",
+  "model_type": "generation"
+}
+```
+
+Both fields are required. `model_type` should be either `generation` or
+`embedding`.

--- a/backend/app/api/endpoints/admin.py
+++ b/backend/app/api/endpoints/admin.py
@@ -1,7 +1,8 @@
 import os
-from fastapi import APIRouter, UploadFile, File, Body
+from fastapi import APIRouter, UploadFile, File
 from ...core.grpc_client import grpc_client_manager
 from ...core.settings import settings
+from ..schemas.admin import ModelSwitchRequest
 
 router = APIRouter()
 
@@ -18,9 +19,9 @@ async def upload_model(file: UploadFile = File(...)):
     return {"success": True, "message": f"模型 {file.filename} 上传成功"}
 
 @router.post("/models/switch")
-async def switch_model(data: dict = Body(...)):
-    model_name = data.get("model_name")
-    model_type = data.get("model_type", "generation")
+async def switch_model(request: ModelSwitchRequest):
+    model_name = request.model_name
+    model_type = request.model_type
     if not model_name:
         return {"success": False, "message": "参数错误：缺少 model_name"}
     await grpc_client_manager.connect()

--- a/backend/app/api/schemas/admin.py
+++ b/backend/app/api/schemas/admin.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class ModelSwitchRequest(BaseModel):
+    """Request body for switching models via the admin API."""
+
+    model_name: str
+    model_type: str


### PR DESCRIPTION
## Summary
- introduce `ModelSwitchRequest` pydantic model
- update admin endpoint to use the new schema
- document the JSON payload for switching models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c031a49883288f595e804123f108