### PR TITLE
Fix admin WebSocket URL

### DIFF
--- a/frontend-admin/src/components/ChatWindow.vue
+++ b/frontend-admin/src/components/ChatWindow.vue
@@ -74,7 +74,8 @@ function scrollToBottom() {
 // 连接 WebSocket
 function connectWs() {
   if (ws) ws.close();
-  ws = new WebSocket('ws://localhost:8000/chat/ws'); // 按需修改地址
+  const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${wsProtocol}://${location.host}/api/chat/ws`);
   ws.onopen = () => { /* 可提示连接成功 */ };
   ws.onerror = () => {
     error.value = '无法连接到AI服务，请稍后重试';


### PR DESCRIPTION
## Summary
- use location protocol and host to build WebSocket URL in `ChatWindow.vue`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857c37823cc83289c9ed88ccee541a5