### PR TITLE
Implement active model tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ must be JSON in the following form:
 
 ```json
 {
-  "model_name": "your-model-file.gguf",
-  "model_type": "generation"
+  "model_name": "your-model-file.gguf"
 }
 ```
 
-Both fields are required. `model_type` should be either `generation` or
-`embedding`.
+The backend will update `backend/active_models.json` with the selected
+generation model.

--- a/backend/active_models.json
+++ b/backend/active_models.json
@@ -1,0 +1,4 @@
+{
+  "generation": "",
+  "embedding": ""
+}

--- a/backend/app/api/schemas/admin.py
+++ b/backend/app/api/schemas/admin.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel
 
 class ModelSwitchRequest(BaseModel):
-    """Request body for switching models via the admin API."""
+    """Request body for switching the generation model."""
 
     model_name: str
-    model_type: str

--- a/backend/app/services/model_store.py
+++ b/backend/app/services/model_store.py
@@ -1,0 +1,55 @@
+import json
+import os
+from pathlib import Path
+
+MODEL_DIR = "/models"
+ACTIVE_MODELS_FILE = Path(__file__).resolve().parents[2] / "active_models.json"
+
+def _ensure_file():
+    if not ACTIVE_MODELS_FILE.exists():
+        ACTIVE_MODELS_FILE.write_text(json.dumps({"generation": "", "embedding": ""}))
+
+def _load_active() -> dict:
+    _ensure_file()
+    try:
+        return json.loads(ACTIVE_MODELS_FILE.read_text())
+    except Exception:
+        return {"generation": "", "embedding": ""}
+
+def _save_active(data: dict) -> None:
+    ACTIVE_MODELS_FILE.write_text(json.dumps(data))
+
+def list_models() -> dict:
+    """Return available models and current active models."""
+    generation_models = []
+    embedding_models = []
+    if os.path.isdir(MODEL_DIR):
+        for name in os.listdir(MODEL_DIR):
+            if name.endswith(".gguf") or name.endswith(".safetensors"):
+                lower = name.lower()
+                if "embed" in lower or "embedding" in lower:
+                    embedding_models.append(name)
+                else:
+                    generation_models.append(name)
+        embed_dir = os.path.join(MODEL_DIR, "embedding-model")
+        if os.path.isdir(embed_dir):
+            for sub in os.listdir(embed_dir):
+                if sub.endswith(".gguf") or sub.endswith(".safetensors"):
+                    embedding_models.append(os.path.join("embedding-model", sub))
+    active = _load_active()
+    return {
+        "generation_models": generation_models,
+        "embedding_models": embedding_models,
+        "current_generation_model": active.get("generation", ""),
+        "current_embedding_model": active.get("embedding", ""),
+    }
+
+def switch_generation_model(model_name: str) -> bool:
+    """Set the active generation model if it exists."""
+    models = list_models()
+    if model_name not in models["generation_models"]:
+        return False
+    active = _load_active()
+    active["generation"] = model_name
+    _save_active(active)
+    return True


### PR DESCRIPTION
## Summary
- track active generation/embedding models in `backend/active_models.json`
- provide `model_store` helper with `list_models` and `switch_generation_model`
- update admin endpoints to use new model store and accept only `model_name`
- document new request body in README

## Testing
- `python -m py_compile backend/app/services/model_store.py backend/app/api/endpoints/admin.py backend/app/api/schemas/admin.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c3799a048328b9dc01b7cf3bf31e