### PR TITLE
Add protos path setup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "protos"))
+
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from app.api.endpoints.admin import admin_router


### PR DESCRIPTION
## Summary
- ensure protos import path added before other imports in backend

## Testing
- `python -m uvicorn app.main:app --reload` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68581ddaa53c832886b8bd4bdffe08c0