### PR TITLE
Add python_package option and adjust proto imports

### DIFF
--- a/backend/app/protos/inference.proto
+++ b/backend/app/protos/inference.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package inference;
 
+option python_package = "app.protos";
+
 service InferenceService {
     rpc ChatStream (ChatRequest) returns (stream ChatResponse);
     rpc ListAvailableModels (Empty) returns (ModelListResponse);

--- a/backend/app/protos/inference_pb2.py
+++ b/backend/app/protos/inference_pb2.py
@@ -28,7 +28,7 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0finference.prot
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'inference_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'app.protos.inference_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_MODELTYPE']._serialized_start=474

--- a/backend/app/protos/inference_pb2_grpc.py
+++ b/backend/app/protos/inference_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import inference_pb2 as inference__pb2
+from . import inference_pb2 as inference__pb2
 
 GRPC_GENERATED_VERSION = '1.73.0'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
## Summary
- add `python_package` option to `inference.proto`
- regenerate proto stubs with relative imports

## Testing
- `python -m py_compile backend/app/protos/inference_pb2.py backend/app/protos/inference_pb2_grpc.py`
- `python -m grpc_tools.protoc --proto_path=backend/app/protos --python_out=backend/app/protos --grpc_python_out=backend/app/protos backend/app/protos/inference.proto` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68581dd8670083289b3b9b34256ee265