### PR TITLE
Remove python_package from proto

### DIFF
--- a/backend/app/protos/inference.proto
+++ b/backend/app/protos/inference.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 package inference;
 
-option python_package = "app.protos";
 
 service InferenceService {
     rpc ChatStream (ChatRequest) returns (stream ChatResponse);

--- a/backend/app/protos/inference_pb2.py
+++ b/backend/app/protos/inference_pb2.py
@@ -28,7 +28,7 @@ DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0finference.prot
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'app.protos.inference_pb2', _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'inference_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_MODELTYPE']._serialized_start=474

--- a/backend/app/protos/inference_pb2_grpc.py
+++ b/backend/app/protos/inference_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-from . import inference_pb2 as inference__pb2
+import inference_pb2 as inference__pb2
 
 GRPC_GENERATED_VERSION = '1.73.0'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
## Summary
- remove the python_package option from `inference.proto`
- update generated grpc files to match

## Testing
- `docker compose up --build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685824d003f08328bc587b4656525084