### PR TITLE
Pin dependency versions and add rebuild note

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,17 @@ must be JSON in the following form:
 
 The backend will update `models/active_models.json` with the selected
 generation model.
+
+### Updating Dependencies
+
+The `backend` and `inference` services use pinned Python package versions
+defined in their respective `requirements.txt` files. If you modify these
+dependencies or encounter build/runtime errors, rebuild the Docker images to
+ensure the changes are applied:
+
+```bash
+docker compose build
+docker compose up
+```
+
+Rebuilding guarantees the containers use the updated packages.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,14 +1,14 @@
-fastapi
-uvicorn
-pydantic
-requests         # ← 必须补上
-sqlmodel
-python-dotenv
-grpcio
-grpcio-tools
-websockets
+fastapi==0.110.0
+uvicorn==0.27.1
+pydantic==2.7.1
+requests==2.31.0         # ← 必须补上
+sqlmodel==0.0.16
+python-dotenv==1.0.1
+grpcio==1.62.1
+grpcio-tools==1.62.1
+websockets==12.0
 # 其它你需要的包
-pydantic-settings
+pydantic-settings==2.1.0
 # ... 其他依赖
-python-multipart
-protobuf
+python-multipart==0.0.9
+protobuf==4.25.3

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -1,11 +1,11 @@
 numpy==1.26.4
-grpcio
-grpcio-tools
-protobuf
+grpcio==1.62.1
+grpcio-tools==1.62.1
+protobuf==4.25.3
 transformers
 torch
-fastapi
-uvicorn
+fastapi==0.110.0
+uvicorn==0.27.1
 llama-cpp-python[cuda]
 faiss-gpu
 sentence-transformers


### PR DESCRIPTION
## Summary
- pin key python packages in backend/inference requirements
- explain how to rebuild Docker images after updating dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582767d1b8832899009c1e0303568f