### PR TITLE
Add gRPC stub regeneration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,23 @@ must be JSON in the following form:
 
 The backend will update `models/active_models.json` with the selected
 generation model.
+
+### Regenerating gRPC Stubs
+
+If you modify `inference.proto`, regenerate the Python stubs so that both the
+`backend` and `inference` copies stay in sync. From the repository root run:
+
+```bash
+python -m grpc_tools.protoc -I backend/app/protos \
+    --python_out=backend/app/protos \
+    --grpc_python_out=backend/app/protos \
+    backend/app/protos/inference.proto
+python -m grpc_tools.protoc -I inference/app/protos \
+    --python_out=inference/app/protos \
+    --grpc_python_out=inference/app/protos \
+    inference/app/protos/inference.proto
+```
+
+Docker automatically performs this step during image builds, but keeping the
+generated files committed avoids mismatches between local sources and what the
+containers see at build time.


### PR DESCRIPTION
## Summary
- document command to regenerate protobuf stubs
- note that backend and inference copies must be updated
- mention Docker runs the command but keeping stubs synced avoids mismatches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68582766ffe483289983878e06449af7