### PR TITLE
Fix backend build docs and pin grpc deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ From the repository root, execute:
 docker compose up --build
 ```
 
+If the build fails with an error such as `Option python_package unknown`, your
+Docker cache may still contain an old copy of `inference.proto`. Rebuilding
+without the cache ensures the latest proto file bundled with `grpcio-tools` is
+used:
+
+```bash
+docker compose build --no-cache backend
+```
+
 The services will be available on the following ports:
 
 - **Backend API** – [http://localhost:8000](http://localhost:8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,14 +1,14 @@
-fastapi
-uvicorn
-pydantic
-requests         # ← 必须补上
-sqlmodel
-python-dotenv
-grpcio
-grpcio-tools
-websockets
+fastapi>=0.110
+uvicorn>=0.24
+pydantic>=2.5
+requests>=2.31         # ← 必须补上
+sqlmodel>=0.0.16
+python-dotenv>=1.0
+grpcio>=1.56
+grpcio-tools>=1.56
+websockets>=12.0
 # 其它你需要的包
-pydantic-settings
+pydantic-settings>=2.2
 # ... 其他依赖
-python-multipart
-protobuf
+python-multipart>=0.0.7
+protobuf>=4.21


### PR DESCRIPTION
## Summary
- pin packages in `backend/requirements.txt`
- mention clearing the Docker cache if build errors occur

## Testing
- `docker compose build backend` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6858276664208328a3a71857651b03f2