### PR TITLE
Specify protobuf 6.x requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a simple knowledge-base system built from several servi
 
 - Docker and Docker Compose installed
 - At least one `.gguf` or `.safetensors` model file under `models/` before starting (embedding model optional)
+- Python package `protobuf` version 6.x
 
 ### Build and Run
 
@@ -33,6 +34,10 @@ used:
 ```bash
 docker compose build --no-cache backend
 ```
+
+The application depends on `protobuf` 6.x. If your images were built
+with an older major version, rebuild all services without the Docker
+cache to avoid import errors.
 
 The services will be available on the following ports:
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,5 +9,5 @@ grpcio-tools==1.62.1
 websockets==12.0
 pydantic-settings==2.1.0
 python-multipart==0.0.9
-protobuf==4.25.3
+protobuf>=6.31.0
 

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.26.4
 grpcio==1.62.1
 grpcio-tools==1.62.1
-protobuf==4.25.3
+protobuf>=6.31.0
 transformers
 torch
 fastapi==0.110.0


### PR DESCRIPTION
## Summary
- upgrade protobuf in backend and inference requirements
- document protobuf 6.x in README

## Testing
- `docker compose build --no-cache` *(fails: `bash: docker: command not found`)*
- `docker compose up` *(fails: `bash: docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68582ed36c1483288a382b56b61764a7