### PR TITLE
Fix gRPC server env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./backend/app:/app/app
       - ./models/active_models.json:/models/active_models.json
     environment:
-      - GRPC_SERVER_ADDRESS=inference:50051
+      - GRPC_SERVER=inference:50051
       - VECTOR_DB_HOST=vector-db
       - VECTOR_DB_PORT=8000
     depends_on:


### PR DESCRIPTION
## Summary
- set `GRPC_SERVER=inference:50051` in `docker-compose.yml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68583a7655a0832899e2e31cad3cc919