### PR TITLE
Fix backend settings import

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.api.endpoints.admin import router as admin_router
 from app.api.endpoints.chat import router as chat_router
 from app.services.chat_service import ConnectionManager
-from app.core.config import settings
+from app.core.settings import settings
 import grpc
 from app.protos import inference_pb2_grpc
 import logging


### PR DESCRIPTION
## Summary
- fix module path for settings in `backend/app/main.py`

## Testing
- `PYTHONPATH=backend python -m compileall backend/app`

------
https://chatgpt.com/codex/tasks/task_e_6858c49d888c8328a4a40140343962df