### PR TITLE
Fix gRPC env var

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,7 +43,7 @@ async def startup_event():
     try:
         # --- 这是关键修改 ---
         # 从环境变量中读取 gRPC 服务器地址
-        grpc_server_address = os.getenv("GRPC_SERVER_ADDRESS", "localhost:50051")
+        grpc_server_address = os.getenv("GRPC_SERVER", "localhost:50051")
         logger.info(f"Connecting to gRPC server at: {grpc_server_address}")
         
         # 使用配置的地址建立 gRPC 连接


### PR DESCRIPTION
## Summary
- use `GRPC_SERVER` environment variable in backend startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c49d8a6483288c4e12c85dfe29fb