### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ docker compose up
 ```
 
 Rebuilding guarantees the containers use the updated packages.
-=======
 ### Regenerating gRPC Stubs
 
 If you modify `inference.proto`, regenerate the Python stubs so that both the


### PR DESCRIPTION
## Summary
- drop leftover `=======` delimiter line from the README
- inspected the file for other truncated or extraneous text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68598258aee08328b43f26a834a5beaf