### PR TITLE
Fix relative imports for gRPC modules

### DIFF
--- a/backend/app/protos/inference_pb2_grpc.py
+++ b/backend/app/protos/inference_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import inference_pb2 as inference__pb2
+from . import inference_pb2 as inference__pb2
 
 GRPC_GENERATED_VERSION = '1.73.0'
 GRPC_VERSION = grpc.__version__

--- a/inference/app/protos/inference_pb2_grpc.py
+++ b/inference/app/protos/inference_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import inference_pb2 as inference__pb2
+from . import inference_pb2 as inference__pb2
 
 GRPC_GENERATED_VERSION = '1.73.0'
 GRPC_VERSION = grpc.__version__


### PR DESCRIPTION
## Summary
- update gRPC generated files to use relative imports

## Testing
- `python -m py_compile backend/app/protos/inference_pb2_grpc.py`
- `python -m py_compile inference/app/protos/inference_pb2_grpc.py`
- `python backend/app/main.py` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685982549bdc8328b93ec6785badc0de