### PR TITLE
Add ninja-build for llama-cpp build

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     git \
     cmake \
+    ninja-build \
     pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
## Summary
- add `ninja-build` to inference Dockerfile dependencies

## Testing
- `docker build -t inference-test -f inference/Dockerfile inference` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0d42e490832888b8b63774484c82