### PR TITLE
Update llama-cpp install instructions

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -28,7 +28,7 @@ RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https:/
 ENV CMAKE_ARGS="-DGGML_CUDA=on"
 ENV FORCE_CUDA="1"
 # Note: We only force compilation for this specific package
-RUN pip3 install --no-cache-dir --force-reinstall --no-binary llama-cpp-python "llama-cpp-python[cuda]"
+RUN pip3 install --no-cache-dir --force-reinstall llama-cpp-python
 
 # --- 4. Install Remaining Python Dependencies ---
 # Set the working directory

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -5,6 +5,6 @@ protobuf>=6.31.0
 transformers
 fastapi==0.110.0
 uvicorn==0.27.1
-llama-cpp-python[cuda]
+llama-cpp-python>=0.2.74
 faiss-gpu
 sentence-transformers


### PR DESCRIPTION
## Summary
- install `llama-cpp-python` without the `[cuda]` extra
- relax requirements to `llama-cpp-python>=0.2.74`

## Testing
- `docker build -t test-inference:latest inference/` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a289547e48328894e47709583f905