### PR TITLE
Update inference Dockerfile for GGML CUDA

### DIFF
--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -37,7 +37,7 @@ COPY requirements.txt /app/requirements.txt
 
 # Set environment variables to force llama-cpp-python to compile with CUDA support.
 # This needs to be set before installing the requirements.
-ENV CMAKE_ARGS="-DLLAMA_CUBLAS=on"
+ENV CMAKE_ARGS="-DGGML_CUDA=on"
 ENV FORCE_CUDA="1"
 
 # Install all other dependencies from requirements.txt.


### PR DESCRIPTION
## Summary
- enable GGML CUDA build flag for `llama-cpp-python` in the inference image

## Testing
- `docker compose build inference` *(fails: `docker: command not found`)*
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a332b816c832887e36378fb949d1a