### PR TITLE
Add local PyTorch wheels dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ docker compose up
 ```
 
 Rebuilding guarantees the containers use the updated packages.
+
+### Updating PyTorch Wheels
+
+The inference image installs PyTorch from local wheel files found in
+`inference/pytorch-wheels/`. These wheels are not committed to the repository.
+When upgrading PyTorch, manually download the CUDA 12.1 builds of
+`torch`, `torchvision` and `torchaudio` from the official
+[PyTorch wheel index](https://download.pytorch.org/whl/cu121) and place them in
+that directory before rebuilding the containers.
 ### Regenerating gRPC Stubs
 
 If you modify `inference.proto`, regenerate the Python stubs so that both the

--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -24,9 +24,11 @@ ENV LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
 ENV PATH="/usr/local/cuda/bin:${PATH}"
 
 # --- 3. Install PyTorch with CUDA Support ---
-# This is the most reliable way to install PyTorch with GPU support.
-# It fetches pre-compiled wheels for CUDA 12.1.
-RUN pip3 install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+# Pre-download the required wheels and copy them into the image. This avoids
+# reaching out to the remote index during the build which is useful for
+# offline or reproducible setups.
+COPY pytorch-wheels /tmp/pytorch-wheels
+RUN pip3 install --no-cache-dir /tmp/pytorch-wheels/*.whl
 
 # --- 4. Install Remaining Python Dependencies (Including llama-cpp-python) ---
 # Set the working directory

--- a/inference/pytorch-wheels/README.md
+++ b/inference/pytorch-wheels/README.md
@@ -1,0 +1,5 @@
+# PyTorch Wheels
+
+This directory should contain the `torch`, `torchvision` and `torchaudio` wheel files matching CUDA 12.1 used by the inference Docker image. These files are not included in the repository.
+
+Download the appropriate wheels from [https://download.pytorch.org/whl/cu121](https://download.pytorch.org/whl/cu121) on a machine with internet access and place them in this folder before building the Docker image.


### PR DESCRIPTION
## Summary
- add placeholder folder for PyTorch wheels
- change inference Dockerfile to install PyTorch from local wheels
- document manual wheel updates in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a3b5eedc88328b930d6d6bc250764