### PR TITLE
docs: add knowledge base API info

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ must be JSON in the following form:
 The backend will update `models/active_models.json` with the selected
 generation model.
 
+### Managing Knowledge Documents
+
+Documents uploaded through the admin interface are saved under
+`knowledge_base_docs/`, which is mounted into the backend container for
+persistence. The following admin API endpoints are available:
+
+- `POST /api/admin/knowledge/upload` – upload a `.txt` file
+- `GET  /api/admin/knowledge/list` – list stored documents
+- `GET  /api/admin/knowledge/download?file=<name>` – download a document
+- `DELETE /api/admin/knowledge/delete?file=<name>` – remove a document
+
+The admin UI at `http://localhost:8081/knowledge-base` provides a simple file
+uploader for these operations.
+
+### Embedding API
+
+If an embedding model is loaded, the endpoint
+`GET /api/embedding/embed_doc?file_name=<name>` returns the vector embedding for
+a stored document.
+
 
 The `backend` and `inference` services use pinned Python package versions
 defined in their respective `requirements.txt` files. If you modify these


### PR DESCRIPTION
## Summary
- document new admin endpoints for uploading and listing knowledge documents
- add note about embedding API

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e57023d14832889c2f5e5b112de7d