### PR TITLE
Fix embedding endpoint async call

### DIFF
--- a/backend/app/api/embedding.py
+++ b/backend/app/api/embedding.py
@@ -1,12 +1,15 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
 from app.services.knowledge_base import kb_service
 
 router = APIRouter()
 
 @router.get("/embed_doc")
-def embed_document_api(file_name: str = Query(...)):
+async def embed_document_api(file_name: str = Query(...)):
     """输入知识库中的文件名，返回embedding向量"""
-    result = kb_service.embed_document(file_name)
-    if result is None:
-        return {"error": "file not found"}
-    return {"embedding": result}
+    try:
+        result = await kb_service.embed_document(file_name)
+        return result
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="file not found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/endpoints/embedding.py
+++ b/backend/app/api/endpoints/embedding.py
@@ -1,12 +1,15 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
 from app.services.knowledge_base import kb_service
 
 router = APIRouter()
 
 @router.get("/embed_doc")
-def embed_document_api(file_name: str = Query(...)):
+async def embed_document_api(file_name: str = Query(...)):
     """输入知识库中的文件名，返回embedding向量"""
-    result = kb_service.embed_document(file_name)
-    if result is None:
-        return {"error": "file not found"}
-    return {"embedding": result}
+    try:
+        result = await kb_service.embed_document(file_name)
+        return result
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="file not found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## Summary
- make `/embed_doc` async and await the service call
- return errors via HTTP status codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686003044184832882e8263a095d9fa1