### PR TITLE
Remove unused shutil import

### DIFF
--- a/backend/app/services/knowledge_base.py
+++ b/backend/app/services/knowledge_base.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import logging
 from typing import List, Optional
 import chromadb


### PR DESCRIPTION
## Summary
- tidy `backend/app/services/knowledge_base.py` by removing leftover import

## Testing
- `pytest -q`
- `ruff check backend/app/services/knowledge_base.py` *(fails: E/F warnings about unrelated code)*

------
https://chatgpt.com/codex/tasks/task_e_68600303f9c88328991f8256786ad472