### PR TITLE
Add token limit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Embedding models can be placed under `models/embedding-model/`. A list of URLs f
 
 Once the files are in place you can visit `http://localhost:8081/model-management` to switch or upload models.
 
+### Generation Limits
+
+The inference service streams at most `150` new tokens by default. Set the
+`MAX_NEW_TOKENS` environment variable to change this limit. If `STOP_TOKEN` is
+defined, generation stops early whenever the substring appears in the output.
+
 ### Switching Models via API
 
 The backend exposes a `POST /api/admin/models/switch` endpoint. The request body


### PR DESCRIPTION
## Summary
- add optional MAX_NEW_TOKENS and STOP_TOKEN env vars
- limit generation tokens and early stop by STOP_TOKEN
- document env variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601c7211f08328b0d98d0f1efd0031