### PR TITLE
Add END token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ docker compose up
 
 Rebuilding guarantees the containers use the updated packages.
 
+### Stop Token
+
+During chat generation the backend instructs the model to append `<END>` once it
+finishes reasoning. The inference service watches the output stream and stops
+producing further tokens as soon as this marker appears. The WebSocket client
+still receives `[DONE]` when the stream ends.
+
 ### Updating PyTorch Wheels
 
 The inference image installs PyTorch from local wheel files found in

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -5,6 +5,8 @@ from ...core.grpc_client import grpc_client_manager
 from ...services.knowledge_base import kb_service
 import logging
 
+END_TOKEN = "<END>"
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -17,7 +19,8 @@ def build_prompt_with_context(query: str, context: list[str]) -> str:
     prompt = f"""
     请根据以下提供的上下文信息来回答用户的问题。请确保你的回答完全基于这些信息，
 不要使用任何外部知识。如果上下文信息不足以回答问题，请直接说“根据我掌握的知识，
-我无法回答这个问题”。在回答时，请先分步骤思考，再给出最终的结论。
+我无法回答这个问题”。在回答时，请先分步骤思考，再给出最终的结论，
+并在最终结论后输出 {END_TOKEN} 作为结束标记。
 
     上下文信息:
     ---


### PR DESCRIPTION
## Summary
- prompt the model to emit `<END>` when its reasoning is complete
- stop inference stream once the `<END>` marker is produced
- document the stop token behaviour

## Testing
- `python -m py_compile backend/app/api/endpoints/chat.py inference/app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68601c7348048328a79fa758d03798fb