### PR TITLE
Enable llama_cpp caching and toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ When upgrading PyTorch, manually download the CUDA 12.1 builds of
 `torch`, `torchvision` and `torchaudio` from the official
 [PyTorch wheel index](https://download.pytorch.org/whl/cu121) and place them in
 that directory before rebuilding the containers.
+
+### Caching with `llama_cpp`
+
+The inference service now enables key/value caching when generating text. This
+improves throughput but increases memory usage. Set the environment variable
+`LLAMA_USE_CACHE=0` when starting the container to disable caching if your
+system has limited RAM.
 ### Regenerating gRPC Stubs
 
 If you modify `inference.proto`, regenerate the Python stubs so that both the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
       - LLAMA_CUBLAS=1
+      - LLAMA_USE_CACHE=1
     gpus: all
     deploy:
       resources:

--- a/inference/app/main.py
+++ b/inference/app/main.py
@@ -15,6 +15,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 MODELS_PATH = "/models/"
+USE_CACHE = os.getenv("LLAMA_USE_CACHE", "1").lower() not in ("0", "false", "no")
 
 class ModelStatus(Enum):
     IDLE = "IDLE"
@@ -127,9 +128,19 @@ class ModelManager:
         messages.append({"role": "user", "content": query})
         if self.model_type in ("qwen", "yi"):
             prompt = build_prompt_qwen(messages)
-            yield from (o["choices"][0].get("text", "") for o in self.model.create_completion(prompt=prompt, stream=True))
+            yield from (
+                o["choices"][0].get("text", "")
+                for o in self.model.create_completion(
+                    prompt=prompt, stream=True, use_cache=USE_CACHE
+                )
+            )
         else:
-            yield from (o["choices"][0].get("delta", {}).get("content", "") for o in self.model.create_chat_completion(messages=messages, stream=True))
+            yield from (
+                o["choices"][0].get("delta", {}).get("content", "")
+                for o in self.model.create_chat_completion(
+                    messages=messages, stream=True, use_cache=USE_CACHE
+                )
+            )
 
 model_manager = ModelManager()
 

--- a/inference/app/services/model_service.py
+++ b/inference/app/services/model_service.py
@@ -4,6 +4,8 @@ from llama_cpp import Llama
 from sentence_transformers import SentenceTransformer
 from .utils import get_chat_handler
 
+USE_CACHE = os.getenv("LLAMA_USE_CACHE", "1").lower() not in ("0", "false", "no")
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 class RAGService:
@@ -130,7 +132,8 @@ class RAGService:
                 stream = self.generation_model(
                     prompt=prompt,
                     max_tokens=4096,
-                    stream=True
+                    stream=True,
+                    use_cache=USE_CACHE,
                 )
                 for output in stream:
                     token = output["choices"][0].get("text", "")
@@ -150,7 +153,8 @@ class RAGService:
                 prompt=final_prompt,
                 stop=stop_sequences,
                 max_tokens=4096,
-                stream=True
+                stream=True,
+                use_cache=USE_CACHE,
             )
             for output in stream:
                 token = output["choices"][0].get("text", "")


### PR DESCRIPTION
## Summary
- pass `use_cache=USE_CACHE` into llama calls
- add `LLAMA_USE_CACHE` toggle for inference service
- document llama caching behaviour
- expose cache env variable in compose file

## Testing
- `python -m py_compile inference/app/main.py inference/app/services/model_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68601c755e2083288aa935338a9baad0