### PR TITLE
Remove invalid inference model_config mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./models:/models:rw
-      - ./inference/app/model_config.json:/app/model_config.json:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all


### PR DESCRIPTION
## Summary
- fix docker-compose by removing model_config.json mount

## Testing
- `find . -name '*.py' -print0 | xargs -0 -n1 python3 -m py_compile` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_686027440c688328991887032bfb75b9