### PR TITLE
Replace deprecated llama-cpp use_cache argument

### DIFF
--- a/inference/app/main.py
+++ b/inference/app/main.py
@@ -133,7 +133,7 @@ class ModelManager:
             stream = self.model.create_completion(
                 prompt=prompt,
                 stream=True,
-                use_cache=USE_KV_CACHE,
+                cache=USE_KV_CACHE,
                 max_tokens=MAX_TOKENS,
                 stop=EARLY_STOP_TOKENS or None,
             )
@@ -145,7 +145,7 @@ class ModelManager:
             stream = self.model.create_chat_completion(
                 messages=messages,
                 stream=True,
-                use_cache=USE_KV_CACHE,
+                cache=USE_KV_CACHE,
                 max_tokens=MAX_TOKENS,
                 stop=EARLY_STOP_TOKENS or None,
             )

--- a/inference/app/services/model_service.py
+++ b/inference/app/services/model_service.py
@@ -138,7 +138,7 @@ class RAGService:
                 stream = self.generation_model(
                     prompt=prompt,
                     stream=True,
-                    use_cache=USE_KV_CACHE,
+                    cache=USE_KV_CACHE,
                     max_tokens=limit,
                     stop=EARLY_STOP_TOKENS or None,
                 )
@@ -163,7 +163,7 @@ class RAGService:
                 prompt=final_prompt,
                 stop=stop_sequences,
                 stream=True,
-                use_cache=USE_KV_CACHE,
+                cache=USE_KV_CACHE,
                 max_tokens=limit,
             )
             for output in stream:


### PR DESCRIPTION
## Summary
- update inference server to use `cache` argument instead of `use_cache`
- update RAG service streaming generation to use `cache`

## Testing
- `python inference/app/main.py` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_6860b3e0dc848328bdfdf50d934ebef6