### PR TITLE
Fix CUDA build option for inference

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
-      - LLAMA_CUBLAS=1
+      - GGML_CUDA=1
       - ENABLE_CACHE=1
     gpus: all
     deploy:

--- a/inference/Dockerfile
+++ b/inference/Dockerfile
@@ -23,7 +23,7 @@ RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/libcuda.s
     && ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/libcuda.so.1 \
     && export LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}" \
     && python3 -m pip install --upgrade pip \
-    && export CMAKE_ARGS="-DLLAMA_CUBLAS=on" \
+    && export CMAKE_ARGS="-DGGML_CUDA=on" \
     && export FORCE_CMAKE=1 \
     && pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- use `GGML_CUDA` when building inference image
- update docker-compose to pass `GGML_CUDA` env var

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68610f99e96c832881ec7a3cd6f3aa00