### PR TITLE
Upgrade llama-cpp usage

### DIFF
--- a/inference/app/main.py
+++ b/inference/app/main.py
@@ -10,8 +10,7 @@ import logging
 import threading
 import time
 from app.utils import IS_GPU_AVAILABLE
-# 确保从配置中导入了 USE_KV_CACHE
-from app.config import MAX_TOKENS, EARLY_STOP_TOKENS, USE_KV_CACHE
+from app.config import MAX_TOKENS, EARLY_STOP_TOKENS
 from enum import Enum
 
 logging.basicConfig(
@@ -150,7 +149,6 @@ class ModelManager:
             stream = self.model.create_completion(
                 prompt=prompt,
                 stream=True,
-                cache=USE_KV_CACHE,  # ★ cache参数已启用
                 max_tokens=MAX_TOKENS,
                 stop=EARLY_STOP_TOKENS or None,
             )
@@ -162,7 +160,6 @@ class ModelManager:
             stream = self.model.create_chat_completion(
                 messages=messages,
                 stream=True,
-                cache=USE_KV_CACHE, # ★ cache参数已启用
                 max_tokens=MAX_TOKENS,
                 stop=EARLY_STOP_TOKENS or None,
             )

--- a/inference/app/services/model_service.py
+++ b/inference/app/services/model_service.py
@@ -4,7 +4,7 @@ from llama_cpp import Llama
 from sentence_transformers import SentenceTransformer
 from .utils import get_chat_handler
 from typing import Optional
-from app.config import MAX_TOKENS, EARLY_STOP_TOKENS, USE_KV_CACHE
+from app.config import MAX_TOKENS, EARLY_STOP_TOKENS
 
 DEFAULT_MAX_NEW_TOKENS = int(os.getenv("MAX_NEW_TOKENS", "150"))
 STOP_TOKEN = os.getenv("STOP_TOKEN")
@@ -138,7 +138,6 @@ class RAGService:
                 stream = self.generation_model(
                     prompt=prompt,
                     stream=True,
-                    cache=USE_KV_CACHE,
                     max_tokens=limit,
                     stop=EARLY_STOP_TOKENS or None,
                 )
@@ -163,7 +162,6 @@ class RAGService:
                 prompt=final_prompt,
                 stop=stop_sequences,
                 stream=True,
-                cache=USE_KV_CACHE,
                 max_tokens=limit,
             )
             for output in stream:

--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -5,4 +5,4 @@ protobuf==3.20.3
 transformers
 sentence-transformers==2.6.1
 grpcio-reflection
-llama-cpp-python==0.2.90
+llama-cpp-python>=0.2.90


### PR DESCRIPTION
## Summary
- update inference dependency to llama-cpp-python >=0.2.90
- remove deprecated `cache` parameter from generation calls
- adjust imports after removing cache usage

## Testing
- `python -m py_compile inference/app/main.py inference/app/services/model_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861545b7828832888128a50e6cc484c