### PR TITLE
Implement session-based chat history

### DIFF
--- a/backend/app/core/grpc_client.py
+++ b/backend/app/core/grpc_client.py
@@ -25,11 +25,12 @@ class GrpcClientManager:
         self.channel = None
         logger.info("Disconnected from gRPC server")
 
-    async def chat(self, messages):
+    async def chat(self, req: inference_pb2.ChatRequest):
+        """Stream chat completions from the inference server."""
         if not self.stub:
             yield "[Error: no connection]"
             return
-        req = inference_pb2.ChatRequest(messages=[inference_pb2.Message(role=m["role"], content=m["content"]) for m in messages])
+
         async for resp in self.stub.ChatStream(req):
             if resp.HasField("token"):
                 yield resp.token

--- a/backend/app/services/session_manager.py
+++ b/backend/app/services/session_manager.py
@@ -1,0 +1,21 @@
+import uuid
+from typing import List, Dict
+
+# Global in-memory storage for chat sessions
+sessions: Dict[str, List[dict]] = {}
+
+def create_session() -> str:
+    """Create a new session and return its ID."""
+    session_id = str(uuid.uuid4())
+    sessions[session_id] = []
+    return session_id
+
+def get_session_context(session_id: str) -> List[dict]:
+    """Retrieve message history for a session."""
+    return sessions.get(session_id, [])
+
+def append_message(session_id: str, message: dict):
+    """Append a message to the session history."""
+    if session_id not in sessions:
+        sessions[session_id] = []
+    sessions[session_id].append(message)


### PR DESCRIPTION
## Summary
- store chat sessions in a new `session_manager` service
- update `grpc_client` to stream using `ChatRequest`
- revise chat endpoint to build prompts from session history
- preserve session id on the user frontend and send messages as JSON

## Testing
- `python -m py_compile backend/app/core/grpc_client.py backend/app/api/endpoints/chat.py backend/app/services/session_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6861598016a483289b5febe1538cb864