### PR TITLE
Add document management feature

### DIFF
--- a/frontend-admin/src/App.vue
+++ b/frontend-admin/src/App.vue
@@ -7,6 +7,7 @@
       <nav class="navigation">
         <router-link to="/knowledge-base" class="nav-item">知识库管理</router-link>
         <router-link to="/model-management" class="nav-item">模型管理</router-link>
+        <router-link to="/document-management" class="nav-item">文档管理</router-link>
       </nav>
     </aside>
     <main class="main-content">

--- a/frontend-admin/src/router/index.js
+++ b/frontend-admin/src/router/index.js
@@ -5,6 +5,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import KnowledgeBase from '../views/KnowledgeBase.vue';
 import ModelManagement from '../views/ModelManagement.vue';
 import FeedbackReview from '../views/FeedbackReview.vue';
+import DocumentManagement from '../views/DocumentManagement.vue';
 
 // --- Route Definitions ---
 const routes = [
@@ -30,6 +31,12 @@ const routes = [
     // Use the actual component here
     component: FeedbackReview,
     meta: { title: '反馈审查' }
+  },
+  {
+    path: '/document-management',
+    name: 'DocumentManagement',
+    component: DocumentManagement,
+    meta: { title: '文档管理' }
   },
 ];
 

--- a/frontend-admin/src/views/DocumentManagement.vue
+++ b/frontend-admin/src/views/DocumentManagement.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="p-6">
+    <h1 class="text-2xl font-bold mb-4">文档管理</h1>
+    <p class="mb-6 text-gray-600">在这里管理所有已上传到知识库的文档。</p>
+
+    <div v-if="loading" class="text-center">
+      <p>正在加载文档列表...</p>
+    </div>
+
+    <div v-else-if="error" class="text-center text-red-500">
+      <p>加载失败: {{ error }}</p>
+    </div>
+
+    <div v-else class="bg-white shadow rounded-lg">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              文件名 (Source)
+            </th>
+            <th scope="col" class="relative px-6 py-3">
+              <span class="sr-only">操作</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <tr v-if="documents.length === 0">
+            <td colspan="2" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+              知识库中暂无文档
+            </td>
+          </tr>
+          <tr v-for="doc in documents" :key="doc.id">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+              {{ doc.source }}
+            </td>
+            <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <button
+                @click="confirmDelete(doc)"
+                class="text-red-600 hover:text-red-900"
+                :disabled="deleting[doc.id]"
+              >
+                {{ deleting[doc.id] ? '删除中...' : '删除' }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+
+const documents = ref([]);
+const loading = ref(true);
+const error = ref(null);
+const deleting = ref({});
+
+const fetchDocuments = async () => {
+  loading.value = true;
+  error.value = null;
+  try {
+    const response = await axios.get('/api/admin/kb/documents');
+    documents.value = response.data;
+  } catch (err) {
+    error.value = err.response?.data?.detail || err.message;
+  } finally {
+    loading.value = false;
+  }
+};
+
+const confirmDelete = (doc) => {
+  if (window.confirm(`确定要删除文档 "${doc.source}" 吗？此操作不可逆，将删除该文件对应的所有知识库片段。`)) {
+    deleteDocument(doc);
+  }
+};
+
+const deleteDocument = async (doc) => {
+  deleting.value[doc.id] = true;
+  try {
+    await axios.delete(`/api/admin/kb/documents/${encodeURIComponent(doc.source)}`);
+    documents.value = documents.value.filter(d => d.id !== doc.id);
+  } catch (err) {
+    alert(`删除失败: ${err.response?.data?.detail || err.message}`);
+  } finally {
+    deleting.value[doc.id] = false;
+  }
+};
+
+onMounted(() => {
+  fetchDocuments();
+});
+</script>

--- a/modules/backend/app/api/endpoints/knowledge_base.py
+++ b/modules/backend/app/api/endpoints/knowledge_base.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, HTTPException
+from typing import List, Dict
+
+from ...services.knowledge_base import kb_service
+
+router = APIRouter()
+
+@router.get("/documents", response_model=List[Dict[str, any]])
+async def list_documents():
+    """获取所有已上传的文档列表。"""
+    documents = await kb_service.list_all_documents()
+    if documents is None:
+        raise HTTPException(status_code=500, detail="无法从知识库获取文档列表")
+    return documents
+
+@router.delete("/documents/{source_name}")
+async def delete_document(source_name: str):
+    """根据文件名删除知识库中的一个文档。"""
+    success = await kb_service.delete_documents_by_source(source_name)
+    if not success:
+        raise HTTPException(status_code=500, detail=f"删除文档 '{source_name}' 失败")
+    return {"message": f"文档 '{source_name}' 已成功删除"}

--- a/modules/backend/app/main.py
+++ b/modules/backend/app/main.py
@@ -7,6 +7,7 @@ from .core.grpc_client import grpc_client_manager
 import logging
 import asyncio
 from .api.endpoints.knowledge import router as knowledge_router
+from .api.endpoints.knowledge_base import router as knowledge_base_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ app.include_router(chat_router, prefix="/api/chat", tags=["Chat"])
 app.include_router(admin_router, prefix="/api/admin", tags=["Admin"])
 app.include_router(embedding_router, prefix="/api/embedding", tags=["Embedding"])
 app.include_router(knowledge_router, prefix="/api/admin/knowledge")
+app.include_router(knowledge_base_router, prefix="/api/admin/kb", tags=["KnowledgeBase"])
 
 @app.get("/")
 def read_root():


### PR DESCRIPTION
## Summary
- expose admin knowledge base endpoints to list and delete documents
- implement list/delete helpers in knowledge base service
- add document management page in admin frontend
- wire new frontend route and navigation link
- register new backend API router

## Testing
- `python -m py_compile modules/backend/app/services/knowledge_base.py`
- `python -m py_compile modules/backend/app/api/endpoints/knowledge_base.py`
- `python -m py_compile modules/backend/app/main.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861799c384c8328b91691694a9387b4