### PR TITLE
Add nginx reverse proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,38 @@ disable caching or `1` to enable it (the default).
     environment:
       - USE_KV_CACHE=0
 ```
+
+## Deploying with Nginx
+
+The project ships with an optional Nginx reverse proxy configuration located
+under `nginx/`. It routes incoming HTTPS traffic to the backend API and the two
+Vue frontends while Certbot manages the TLS certificates.
+
+### Obtaining certificates
+
+Edit `nginx/nginx.conf` and replace the example domain names with your own.
+Create the certificate volumes and run Certbot once to generate the initial
+certificates:
+
+```bash
+docker volume create certbot-etc
+docker volume create certbot-web
+docker compose run --rm certbot certonly --webroot \
+  --webroot-path=/var/www/certbot \
+  -d example.com -d api.example.com -d admin.example.com \
+  --email you@example.com --agree-tos --no-eff-email
+```
+
+The certificates reside in the `certbot-etc` volume. The `certbot` service runs
+`certbot renew` every 12&nbsp;hours to keep them up to date.
+
+### Starting the stack
+
+Start all containers, including Nginx, with:
+
+```bash
+docker compose up --build
+```
+
+Nginx exposes ports `80` and `443` while the individual services communicate
+through the internal Docker network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
     build:
       context: ./modules/backend
       dockerfile: Dockerfile
-    ports:
-      - "8000:8000"
     volumes:
       - ./modules/backend/app:/app/app
       - ./models:/models:ro
@@ -25,8 +23,6 @@ services:
     build:
       context: ./frontend-user
       dockerfile: Dockerfile
-    ports:
-      - "8080:80"
     depends_on:
       - backend
     networks:
@@ -36,8 +32,6 @@ services:
     build:
       context: ./frontend-admin
       dockerfile: Dockerfile
-    ports:
-      - "8081:80"
     volumes:
       - ./frontend-admin:/app
     depends_on:
@@ -82,8 +76,35 @@ services:
     networks:
       - app-network
 
+  nginx:
+    image: nginx:1.25
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/options-ssl-nginx.conf:/etc/nginx/options-ssl-nginx.conf:ro
+      - certbot-web:/var/www/certbot
+      - certbot-etc:/etc/letsencrypt
+    depends_on:
+      - backend
+      - frontend-user
+      - frontend-admin
+    networks:
+      - app-network
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - certbot-etc:/etc/letsencrypt
+      - certbot-web:/var/www/certbot
+    entrypoint: >-
+      sh -c 'trap exit TERM; while :; do sleep 12h & wait $${!}; certbot renew; done'
+
 volumes:
   chroma-data:
+  certbot-etc:
+  certbot-web:
 
 networks:
   app-network:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,87 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile        on;
+
+    upstream backend_service {
+        server backend:8000;
+    }
+
+    upstream frontend_user_service {
+        server frontend-user:80;
+    }
+
+    upstream frontend_admin_service {
+        server frontend-admin:80;
+    }
+
+    server {
+        listen 80;
+        server_name example.com api.example.com admin.example.com;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name api.example.com;
+
+        ssl_certificate /etc/letsencrypt/live/api.example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
+        include /etc/nginx/options-ssl-nginx.conf;
+
+        location / {
+            proxy_pass http://backend_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+        include /etc/nginx/options-ssl-nginx.conf;
+
+        location / {
+            proxy_pass http://frontend_user_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name admin.example.com;
+
+        ssl_certificate /etc/letsencrypt/live/admin.example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/admin.example.com/privkey.pem;
+        include /etc/nginx/options-ssl-nginx.conf;
+
+        location / {
+            proxy_pass http://frontend_admin_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx/options-ssl-nginx.conf
+++ b/nginx/options-ssl-nginx.conf
@@ -1,0 +1,8 @@
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;
+ssl_session_tickets off;
+
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers off;
+
+ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';


### PR DESCRIPTION
## Summary
- add nginx configuration for HTTPS reverse proxying
- include optional Mozilla SSL configuration
- integrate nginx and certbot services in docker compose
- remove direct port exposure from backend and frontends
- document deployment steps using nginx and certbot

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68617dad3d4c832882097139b73a414f