### PR TITLE
Fix knowledge_base endpoint response typing

### DIFF
--- a/modules/backend/app/api/endpoints/knowledge_base.py
+++ b/modules/backend/app/api/endpoints/knowledge_base.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, HTTPException
-from typing import List, Dict
+from typing import List, Dict, Any
 
 from ...services.knowledge_base import kb_service
 
 router = APIRouter()
 
-@router.get("/documents", response_model=List[Dict[str, any]])
+@router.get("/documents", response_model=List[Dict[str, Any]])
 async def list_documents():
     """获取所有已上传的文档列表。"""
     documents = await kb_service.list_all_documents()


### PR DESCRIPTION
## Summary
- fix `any` typo in API response model by using `typing.Any`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68617e4cd4dc8328814b5a88e4909eda