### PR TITLE
Simplify nginx for certbot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,21 +77,20 @@ services:
       - app-network
 
   nginx:
-    image: nginx:1.25
+    image: nginx:1.25.4-alpine
+    container_name: knowledge-base-app-nginx-1
+    restart: always
     ports:
       - "80:80"
-      - "443:443"
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./nginx/options-ssl-nginx.conf:/etc/nginx/options-ssl-nginx.conf:ro
-      - certbot-web:/var/www/certbot
-      - certbot-etc:/etc/letsencrypt
-    depends_on:
-      - backend
-      - frontend-user
-      - frontend-admin
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./data/certbot/www:/var/www/certbot
     networks:
       - app-network
+    # depends_on:
+    #   - backend
+    #   - frontend-user
+    #   - frontend-admin
 
   certbot:
     image: certbot/certbot

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,87 +1,17 @@
-worker_processes 1;
+# ---- 这是用于 Certbot 验证的临时配置 ----
 
-events {
-    worker_connections 1024;
-}
+server {
+    listen 80;
+    # 把这里换成你真实的域名
+    server_name mars-domain.com www.mars-domain.com; 
 
-http {
-    include       mime.types;
-    default_type  application/octet-stream;
-    sendfile        on;
-
-    upstream backend_service {
-        server backend:8000;
+    # 这个 location 是专门给 Certbot 用的，不要修改
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
     }
 
-    upstream frontend_user_service {
-        server frontend-user:80;
-    }
-
-    upstream frontend_admin_service {
-        server frontend-admin:80;
-    }
-
-    server {
-        listen 80;
-        server_name example.com api.example.com admin.example.com;
-
-        location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
-        }
-
-        location / {
-            return 301 https://$host$request_uri;
-        }
-    }
-
-    server {
-        listen 443 ssl;
-        server_name api.example.com;
-
-        ssl_certificate /etc/letsencrypt/live/api.example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/api.example.com/privkey.pem;
-        include /etc/nginx/options-ssl-nginx.conf;
-
-        location / {
-            proxy_pass http://backend_service;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-    }
-
-    server {
-        listen 443 ssl;
-        server_name example.com;
-
-        ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
-        include /etc/nginx/options-ssl-nginx.conf;
-
-        location / {
-            proxy_pass http://frontend_user_service;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-    }
-
-    server {
-        listen 443 ssl;
-        server_name admin.example.com;
-
-        ssl_certificate /etc/letsencrypt/live/admin.example.com/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/admin.example.com/privkey.pem;
-        include /etc/nginx/options-ssl-nginx.conf;
-
-        location / {
-            proxy_pass http://frontend_admin_service;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
+    # 其他所有请求可以暂时返回一个信息，或者重定向
+    location / {
+        return 404; # 或者 rewrite ^ https://$host$request_uri? permanent;
     }
 }


### PR DESCRIPTION
## Summary
- simplify nginx configuration for HTTP-only certbot verification
- update docker-compose to use temporary nginx setup

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6861850b8e3883288778580ce48cb630