### PR TITLE
Add intranet-only compose and nginx config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   backend:
     build:
@@ -84,26 +86,15 @@ services:
       - "80:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
-      - ./data/certbot/www:/var/www/certbot
+    depends_on:
+      - backend
+      - frontend-user
+      - frontend-admin
     networks:
       - app-network
-    # depends_on:
-    #   - backend
-    #   - frontend-user
-    #   - frontend-admin
-
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - certbot-etc:/etc/letsencrypt
-      - certbot-web:/var/www/certbot
-    entrypoint: >-
-      sh -c 'trap exit TERM; while :; do sleep 12h & wait $${!}; certbot renew; done'
 
 volumes:
   chroma-data:
-  certbot-etc:
-  certbot-web:
 
 networks:
   app-network:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,17 +1,46 @@
-# ---- 这是用于 Certbot 验证的临时配置 ----
+# upstream 定义内部服务地址，保持不变
+upstream backend_service {
+    server backend:8000;
+}
+upstream frontend_user_service {
+    server frontend-user:80;
+}
+upstream frontend_admin_service {
+    server frontend-admin:80;
+}
 
+# --- 唯一的 Server Block，处理所有内网流量 ---
 server {
     listen 80;
-    # 把这里换成你真实的域名
-    server_name mars-domain.com www.mars-domain.com; 
+    # server_name 可以用下划线作为通配符，接受所有访问
+    server_name _;
 
-    # 这个 location 是专门给 Certbot 用的，不要修改
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+    # 根路径 -> 用户前端
+    location / {
+        proxy_pass http://frontend_user_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    # 其他所有请求可以暂时返回一个信息，或者重定向
-    location / {
-        return 404; # 或者 rewrite ^ https://$host$request_uri? permanent;
+    # API 路径 -> 后端服务
+    location /api/ {
+        proxy_pass http://backend_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # WebSocket 配置
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+    
+    # 管理员路径 -> 管理员前端
+    location /admin/ {
+        rewrite ^/admin/(.*)$ /$1 break;
+        proxy_pass http://frontend_admin_service;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }


### PR DESCRIPTION
## Summary
- update docker-compose.yml for internal HTTP setup
- simplify nginx.conf for intranet deployments

## Testing
- `docker compose config` *(fails: `docker: command not found`)*
- `docker-compose config` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861881261048328bea4f8979533f1e8