### PR TITLE
Add base path configuration for admin Vite build

### DIFF
--- a/frontend-admin/vite.config.js
+++ b/frontend-admin/vite.config.js
@@ -34,6 +34,8 @@ export default defineConfig({
       }
     }
   },
+  // Base path for serving the admin front-end
+  base: '/admin/',
   // Optional: Configure build options, like output directory
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- configure base path `/admin/` in `frontend-admin/vite.config.js`

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68620e72698c832882a153832ce2012e