### PR TITLE
Add PostCSS config and global CSS to admin app

### DIFF
--- a/frontend-admin/postcss.config.js
+++ b/frontend-admin/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {}, // 使用最新的 @tailwindcss/postcss 插件
+    autoprefixer: {},
+  },
+}

--- a/frontend-admin/src/index.css
+++ b/frontend-admin/src/index.css
@@ -1,0 +1,7 @@
+/* modules/frontend-admin/src/index.css */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* 这里可以放一些全局的、覆盖性的样式，如果需要的话 */

--- a/frontend-admin/src/main.js
+++ b/frontend-admin/src/main.js
@@ -1,3 +1,4 @@
+import './index.css'
 import { createApp } from 'vue'
 
 // Import Element Plus UI Library and its base styles


### PR DESCRIPTION
## Summary
- configure PostCSS for `frontend-admin`
- add a global Tailwind CSS entry file
- load the new global stylesheet in the admin app

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862152c917083289fb0b920ed3f6cb5