### PR TITLE
Update admin frontend configs and styles

### DIFF
--- a/frontend-admin/postcss.config.js
+++ b/frontend-admin/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {}, // 使用最新的 @tailwindcss/postcss 插件
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/frontend-admin/src/App.vue
+++ b/frontend-admin/src/App.vue
@@ -7,7 +7,7 @@
         </svg>
         <h1 class="text-xl font-semibold text-neutral-10">知识库管理后台</h1>
       </div>
-      </header>
+    </header>
 
     <div class="flex flex-1 overflow-hidden">
       <aside class="w-64 bg-neutral-100 border-r border-neutral-80 p-2">
@@ -16,9 +16,9 @@
             v-for="item in navItems"
             :key="item.name"
             :to="item.path"
-            class="px-4 py-2.5 text-sm font-medium rounded-md transition-colors"
-            active-class="bg-salesforce-blue/10 text-salesforce-blue"
-            exact-active-class="bg-salesforce-blue/10 text-salesforce-blue"
+            class="px-4 py-2.5 text-sm font-medium rounded-md transition-colors hover:bg-salesforce-blue/5"
+            active-class="bg-salesforce-blue/10 text-salesforce-blue font-semibold"
+            exact-active-class="bg-salesforce-blue/10 text-salesforce-blue font-semibold"
           >
             {{ item.name }}
           </router-link>
@@ -36,16 +36,9 @@
 import { ref } from 'vue';
 
 const navItems = ref([
-  { name: '仪表盘', path: '/' },
-  { name: '模型管理', path: '/model-management' },
-  { name: '知识库上传', path: '/knowledge-base' },
-  { name: '文档管理', path: '/document-management' },
+  { name: '仪表盘', path: '/admin/' }, // 路径修改为/admin/
+  { name: '模型管理', path: '/admin/model-management' },
+  { name: '知识库上传', path: '/admin/knowledge-base' },
+  { name: '文档管理', path: '/admin/document-management' },
 ]);
 </script>
-
-<style>
-/* 可以在这里添加全局字体等样式 */
-body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-}
-</style>

--- a/frontend-admin/src/index.css
+++ b/frontend-admin/src/index.css
@@ -1,7 +1,28 @@
-/* modules/frontend-admin/src/index.css */
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/* 这里可以放一些全局的、覆盖性的样式，如果需要的话 */
+@layer base {
+  :root {
+    --salesforce-blue: #0070D2;
+    --salesforce-blue-dark: #005FB2;
+    --neutral-100: #FFFFFF;
+    --neutral-95: #F3F3F3;
+    --neutral-80: #E0E0E0;
+    --neutral-50: #6B6B6B;
+    --neutral-10: #181818;
+    --destructive: #EA001E;
+  }
+
+  html, body, #app {
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+  }
+
+   body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
+}

--- a/frontend-admin/src/router/index.js
+++ b/frontend-admin/src/router/index.js
@@ -1,46 +1,19 @@
 import { createRouter, createWebHistory } from 'vue-router';
 
-// --- View Components ---
-// Import all the actual view components we have created.
 import KnowledgeBase from '../views/KnowledgeBase.vue';
 import ModelManagement from '../views/ModelManagement.vue';
 import FeedbackReview from '../views/FeedbackReview.vue';
 import DocumentManagement from '../views/DocumentManagement.vue';
+import Dashboard from '../views/Dashboard.vue';
 
-// --- Route Definitions ---
 const routes = [
-  {
-    path: '/',
-    redirect: '/knowledge-base',
-  },
-  {
-    path: '/knowledge-base',
-    name: 'KnowledgeBase',
-    component: KnowledgeBase,
-    meta: { title: '知识库管理' }
-  },
-  {
-    path: '/model-management',
-    name: 'ModelManagement',
-    component: ModelManagement,
-    meta: { title: '模型管理' }
-  },
-  {
-    path: '/feedback-review',
-    name: 'FeedbackReview',
-    // Use the actual component here
-    component: FeedbackReview,
-    meta: { title: '反馈审查' }
-  },
-  {
-    path: '/document-management',
-    name: 'DocumentManagement',
-    component: DocumentManagement,
-    meta: { title: '文档管理' }
-  },
+  { path: '/admin/', name: 'Home', component: Dashboard },
+  { path: '/admin/model-management', name: 'ModelManagement', component: ModelManagement },
+  { path: '/admin/knowledge-base', name: 'KnowledgeBase', component: KnowledgeBase },
+  { path: '/admin/feedback-review', name: 'FeedbackReview', component: FeedbackReview },
+  { path: '/admin/document-management', name: 'DocumentManagement', component: DocumentManagement },
 ];
 
-// --- Router Instance ---
 const router = createRouter({
   history: createWebHistory(),
   routes,

--- a/frontend-admin/src/views/DocumentManagement.vue
+++ b/frontend-admin/src/views/DocumentManagement.vue
@@ -1,49 +1,25 @@
 <template>
   <div class="p-4 sm:p-6 lg:p-8">
-    <div class="flex items-center justify-between mb-6">
-      <div>
-        <h1 class="text-2xl font-semibold text-neutral-10">文档管理</h1>
-        <p class="mt-1 text-sm text-neutral-50">在这里管理所有已上传到知识库的文档。</p>
-      </div>
-      <div>
-        </div>
+    <div class="mb-8">
+      <h1 class="text-2xl font-semibold text-neutral-10">文档管理</h1>
+      <p class="mt-1 text-sm text-neutral-50">在这里可以查看和删除所有已上传到知识库的文档。</p>
     </div>
-
     <div class="bg-neutral-100 shadow-sm border border-neutral-80 rounded-lg overflow-hidden">
-      <div v-if="loading" class="p-12 text-center text-neutral-50">
-        <p>正在加载文档列表...</p>
-      </div>
-      <div v-else-if="error" class="p-12 text-center text-destructive">
-        <p>加载失败: {{ error }}</p>
-      </div>
-      
+      <div v-if="loading" class="p-12 text-center text-neutral-50"><p>正在加载文档列表...</p></div>
+      <div v-else-if="error" class="p-12 text-center text-destructive"><p>加载失败: {{ error }}</p></div>
       <table v-else class="min-w-full">
         <thead class="border-b border-neutral-80 bg-neutral-95/50">
           <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-neutral-10 uppercase tracking-wider">
-              文件名 (Source)
-            </th>
-            <th scope="col" class="relative px-6 py-3">
-              <span class="sr-only">操作</span>
-            </th>
+            <th scope="col" class="px-6 py-4 text-left text-xs font-semibold text-neutral-50 uppercase tracking-wider">文件名 (Source)</th>
+            <th scope="col" class="relative px-6 py-4"><span class="sr-only">操作</span></th>
           </tr>
         </thead>
         <tbody>
-          <tr v-if="documents.length === 0">
-            <td colspan="2" class="py-12 text-center text-sm text-neutral-50">
-              知识库中暂无文档
-            </td>
-          </tr>
-          <tr v-for="(doc, index) in documents" :key="doc.id" :class="index % 2 === 0 ? 'bg-neutral-100' : 'bg-neutral-95/30'">
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-neutral-10">
-              {{ doc.source }}
-            </td>
+          <tr v-if="documents.length === 0"><td colspan="2" class="py-16 text-center text-sm text-neutral-50">知识库中暂无文档</td></tr>
+          <tr v-for="doc in documents" :key="doc.id" class="hover:bg-salesforce-blue/5">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-neutral-10">{{ doc.source }}</td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-              <button
-                @click="confirmDelete(doc)"
-                class="text-destructive font-medium rounded-md px-3 py-1 hover:bg-destructive/10 transition-colors"
-                :disabled="deleting[doc.id]"
-              >
+              <button @click="confirmDelete(doc)" class="text-destructive font-medium rounded-md px-3 py-1 hover:bg-destructive/10 transition-colors disabled:opacity-50" :disabled="deleting[doc.id]">
                 {{ deleting[doc.id] ? '删除中...' : '删除' }}
               </button>
             </td>
@@ -53,49 +29,31 @@
     </div>
   </div>
 </template>
-
 <script setup>
-// Script 部分保持不变
 import { ref, onMounted } from 'vue';
 import axios from 'axios';
-
 const documents = ref([]);
 const loading = ref(true);
 const error = ref(null);
 const deleting = ref({});
-
 const fetchDocuments = async () => {
-  loading.value = true;
-  error.value = null;
+  loading.value = true; error.value = null;
   try {
     const response = await axios.get('/api/admin/kb/documents'); 
     documents.value = response.data;
-  } catch (err) {
-    error.value = err.response?.data?.detail || err.message;
-  } finally {
-    loading.value = false;
-  }
+  } catch (err) { error.value = err.response?.data?.detail || err.message; }
+  finally { loading.value = false; }
 };
-
 const confirmDelete = (doc) => {
-  if (window.confirm(`确定要删除文档 "${doc.source}" 吗？此操作不可逆。`)) {
-    deleteDocument(doc);
-  }
+  if (window.confirm(`确定要删除文档 "${doc.source}" 吗？此操作不可逆。`)) deleteDocument(doc);
 };
-
 const deleteDocument = async (doc) => {
   deleting.value[doc.id] = true;
   try {
     await axios.delete(`/api/admin/kb/documents/${encodeURIComponent(doc.source)}`);
     documents.value = documents.value.filter(d => d.id !== doc.id);
-  } catch (err) {
-    alert(`删除失败: ${err.response?.data?.detail || err.message}`);
-  } finally {
-    deleting.value[doc.id] = false;
-  }
+  } catch (err) { alert(`删除失败: ${err.response?.data?.detail || err.message}`); }
+  finally { deleting.value[doc.id] = false; }
 };
-
-onMounted(() => {
-  fetchDocuments();
-});
+onMounted(fetchDocuments);
 </script>

--- a/frontend-admin/vite.config.js
+++ b/frontend-admin/vite.config.js
@@ -1,42 +1,22 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-
-// Imports for Element Plus auto-importing
 import AutoImport from 'unplugin-auto-import/vite'
 import Components from 'unplugin-vue-components/vite'
 import { ElementPlusResolver } from 'unplugin-vue-components/resolvers'
 
-// https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     vue(),
-    // Configure AutoImport to automatically import Element Plus functions
-    AutoImport({
-      resolvers: [ElementPlusResolver()],
-    }),
-    // Configure Components to automatically import Element Plus components
-    Components({
-      resolvers: [ElementPlusResolver()],
-    }),
+    AutoImport({ resolvers: [ElementPlusResolver()] }),
+    Components({ resolvers: [ElementPlusResolver()] }),
   ],
   server: {
-    // Configure the development server
-    port: 8081, // Specify the port for the admin UI dev server
+    port: 8081,
     proxy: {
-      // Set up a proxy for API requests to the backend
-      '/api': {
-        // Requests to /api will be forwarded to the backend server
-        target: 'http://localhost:8000',
-        // Change the origin of the host header to the target URL
-        changeOrigin: true,
-        // The path will not be rewritten, so /api/admin/models remains /api/admin/models
-        // rewrite: (path) => path.replace(/^\/api/, '') 
-      }
+      '/api': { target: 'http://localhost:8000', changeOrigin: true }
     }
   },
-  // Base path for serving the admin front-end
-  base: '/admin/',
-  // Optional: Configure build options, like output directory
+  base: '/admin/', // 确保有这一行
   build: {
     outDir: 'dist',
   }


### PR DESCRIPTION
## Summary
- adjust vite config to use `/admin/` base path
- update PostCSS and Tailwind setup
- rewrite main styles in `index.css`
- update main App shell navigation
- finalize document management page
- sync router paths with `/admin` prefix

## Testing
- `npm install --ignore-scripts` *(fails: network access blocked)*
- `npm run build` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68621995d9308328999aa6971ed2b4f0