### PR TITLE
Add model management service and UI

### DIFF
--- a/modules/backend/app/api/endpoints/models.py
+++ b/modules/backend/app/api/endpoints/models.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, UploadFile, File, HTTPException
+import logging
+
+from ....services.model_management import model_service
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+@router.post("/upload")
+async def upload_model_file(file: UploadFile = File(...)):
+    """
+    接收并保存上传的模型文件。
+    """
+    try:
+        file_data = await file.read()
+        model_service.add_model(file.filename, file_data)
+        return {"success": True, "filename": file.filename, "message": "模型上传成功！"}
+    except Exception as e:
+        logger.error(f"上传模型文件 '{file.filename}' 时发生错误: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"上传模型失败: {e}")
+
+@router.get("/list")
+async def list_available_models():
+    """
+    获取已上传的模型列表。
+    """
+    try:
+        models = model_service.list_models()
+        return {"models": models}
+    except Exception as e:
+        logger.error(f"获取模型列表时发生错误: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"获取模型列表失败: {e}")

--- a/modules/backend/app/main.py
+++ b/modules/backend/app/main.py
@@ -8,6 +8,7 @@ import logging
 import asyncio
 from .api.endpoints.knowledge import router as knowledge_router
 from .api.endpoints.knowledge_base import router as knowledge_base_router
+from .api.endpoints.models import router as models_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ app.include_router(chat_router, prefix="/api/chat", tags=["Chat"])
 app.include_router(admin_router, prefix="/api/admin", tags=["Admin"])
 app.include_router(embedding_router, prefix="/api/embedding", tags=["Embedding"])
 app.include_router(knowledge_router, prefix="/api/admin/knowledge")
+app.include_router(models_router, prefix="/api/admin/models", tags=["Models"])
 app.include_router(knowledge_base_router, prefix="/api/admin/kb", tags=["KnowledgeBase"])
 
 @app.get("/")

--- a/modules/backend/app/services/model_management.py
+++ b/modules/backend/app/services/model_management.py
@@ -1,0 +1,37 @@
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+class ModelManagementService:
+    def __init__(self, storage_dir: str = "model_storage"):
+        """
+        初始化模型管理服务。
+        :param storage_dir: 存放上传模型文件的目录名。
+        """
+        self.storage_dir = storage_dir
+        if not os.path.exists(self.storage_dir):
+            os.makedirs(self.storage_dir)
+            logger.info(f"模型存储目录 '{self.storage_dir}' 已创建。")
+
+    def add_model(self, filename: str, file_data: bytes) -> str:
+        """
+        将上传的模型文件保存到本地。
+        """
+        file_path = os.path.join(self.storage_dir, filename)
+        with open(file_path, "wb") as f:
+            f.write(file_data)
+        logger.info(f"模型文件 '{filename}' 已保存到 '{file_path}'。")
+        return file_path
+
+    def list_models(self) -> list[str]:
+        """
+        列出所有已上传的模型文件。
+        """
+        if not os.path.exists(self.storage_dir):
+            return []
+        # 只返回文件名，不包括路径
+        return [f for f in os.listdir(self.storage_dir) if os.path.isfile(os.path.join(self.storage_dir, f))]
+
+# 创建一个全局单例
+model_service = ModelManagementService()


### PR DESCRIPTION
## Summary
- backend: add service `ModelManagementService` for storing uploaded model files
- backend: expose `/api/admin/models` endpoints for uploading and listing models
- backend: register new router in `main.py`
- frontend: replace `ModelManagement.vue` with model upload interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686262a1fa548328b20a46ff3ee157a9