### PR TITLE
Fix relative imports and inference mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     restart: unless-stopped
     volumes:
       # 核心修正: 推理服务从与后端相同的模型存储目录中读取模型
-      - ./model_storage:/app/models:ro # 容器内的路径是 /app/models，与推理服务的代码逻辑匹配
+      - ./model_storage:/models:ro # 容器内的路径是 /models，与推理服务的代码逻辑匹配
     deploy:
       resources:
         reservations:

--- a/modules/backend/app/api/endpoints/chat.py
+++ b/modules/backend/app/api/endpoints/chat.py
@@ -1,13 +1,13 @@
     from fastapi import APIRouter, WebSocket, WebSocketDisconnect, HTTPException, Body
-    # 核心修正：将 '..' 改为 '...'，以正确地从项目顶层导入模块
-    from ...core.grpc_client import grpc_client_manager
-    from ...services.knowledge_base import kb_service
-    from ...services.session_manager import (
+    # 核心修正：将 '...' 改为 '..'，以正确地从项目顶层导入模块
+    from ..core.grpc_client import grpc_client_manager
+    from ..services.knowledge_base import kb_service
+    from ..services.session_manager import (
         create_session,
         get_session_context,
         append_message,
     )
-    from ...protos import inference_pb2
+    from ..protos import inference_pb2
     import logging
     import json
     


### PR DESCRIPTION
## Summary
- correct relative imports in chat endpoint
- mount inference models to `/models` for consistency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627c3b89108328aa8ae8aec8688395