### PR TITLE
Add config for embedding model loading

### DIFF
--- a/modules/backend/app/core/config.py
+++ b/modules/backend/app/core/config.py
@@ -1,0 +1,2 @@
+import os
+EMBEDDING_MODEL_NAME = os.getenv("EMBEDDING_MODEL_NAME", "BAAI/bge-base-zh-v1.5")


### PR DESCRIPTION
## Summary
- add a new `config.py` to backend that defines `EMBEDDING_MODEL_NAME`
- ensure knowledge base service imports from `core.config`
- attempted to rebuild the backend container

## Testing
- `pytest -q`
- `docker compose build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b5c75b208328aeb2e28af81b4b42