### PR TITLE
Switch inference model storage to ./models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ CACHED
 \[inference\]
 docker
 inference/llama_cpp_python-0.2.73-cp310-cp310-linux_x86_64.whl
+!/models/sample-model.gguf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: unless-stopped
     volumes:
       # 核心修正: 推理服务从与后端相同的模型存储目录中读取模型
-      - ./model_storage:/models:ro # 容器内的路径是 /models，与推理服务的代码逻辑匹配
+      - ./models:/models:ro # 容器内的路径是 /models，与推理服务的代码逻辑匹配
     deploy:
       resources:
         reservations:

--- a/models/sample-model.gguf
+++ b/models/sample-model.gguf
@@ -1,0 +1,1 @@
+placeholder model content


### PR DESCRIPTION
## Summary
- mount `./models` into the inference container
- keep a placeholder model file in `models/`
- allow placeholder model to be committed

## Testing
- `docker compose version` *(fails: command not found)*
- `docker-compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b5c72630832898b5afc9181d44e9