### PR TITLE
Update vector DB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple knowledge-base system built from several servi
 
 ## Components
 
-- **backend** – FastAPI API server that exposes REST and WebSocket endpoints. It communicates with the inference service via gRPC and manages uploaded models.
+- **backend** – FastAPI API server that exposes REST and WebSocket endpoints. It communicates with the inference service via gRPC and manages uploaded models. Environment variables are loaded from `modules/backend/.env`; `VECTOR_DB_URL` defaults to `http://vector-db:8000`.
 - **inference** – Python gRPC server that loads language models via `llama_cpp` and performs generation and retrieval. The container runs `python app/main.py` at startup.
 - **frontend-admin** – Vue 3 interface for administrators to upload models and manage the knowledge base.
 - **frontend-user** – Vue 3 chat interface for end users.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       context: ./modules/backend
       dockerfile: Dockerfile
     container_name: knowledge-base-app-backend
+    env_file: ./modules/backend/.env
     volumes:
       - ./modules/backend/app:/app
     ports:

--- a/modules/backend/.env
+++ b/modules/backend/.env
@@ -9,3 +9,4 @@ GRPC_SERVER=inference:50051
 BACKEND_CORS_ORIGINS=["http://localhost:8080","http://localhost:8081"]
 
 INFERENCE_SERVER_URL=inference:50051
+VECTOR_DB_URL=http://vector-db:8000

--- a/modules/backend/app/core/db_client.py
+++ b/modules/backend/app/core/db_client.py
@@ -14,7 +14,7 @@ class VectorDBClient:
     """
     def __init__(self):
         # 从环境变量获取ChromaDB的URL，如果获取不到则使用默认值
-        db_url_str = os.getenv("VECTOR_DB_URL", "http://weaviate:8080")
+        db_url_str = os.getenv("VECTOR_DB_URL", "http://vector-db:8000")
         logger.info(f"正在连接到向量数据库: {db_url_str}")
 
         try:


### PR DESCRIPTION
## Summary
- expose backend env file in docker compose
- set VECTOR_DB_URL in backend .env
- default to http://vector-db:8000 in db client
- document backend env file and vector DB URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68636ae969848328811f5d94873ffc8b