### PR TITLE
Add document management for knowledge base

### DIFF
--- a/modules/backend/app/core/db_client.py
+++ b/modules/backend/app/core/db_client.py
@@ -5,6 +5,8 @@ from langchain_core.documents import Document
 from typing import List
 from urllib.parse import urlparse
 
+from services.embedding import embedding_model
+
 logger = logging.getLogger(__name__)
 
 class VectorDBClient:
@@ -93,6 +95,17 @@ class VectorDBClient:
             return found_docs
         except Exception as e:
             logger.error(f"在向量数据库中通过向量搜索时出错: {e}", exc_info=True)
+            return []
+
+    async def asimilarity_search(self, query: str, k: int = 3) -> List[Document]:
+        """Compute the embedding for a query and search the vector DB."""
+        try:
+            query_embedding = await embedding_model.embed(query)
+            if not query_embedding:
+                return []
+            return await self.search_with_vector(query_embedding, k)
+        except Exception as e:
+            logger.error(f"相似度搜索失败: {e}", exc_info=True)
             return []
 
     def delete_documents_by_source(self, source: str):

--- a/modules/backend/app/services/knowledge_base.py
+++ b/modules/backend/app/services/knowledge_base.py
@@ -1,18 +1,22 @@
 import logging
+import os
 from typing import List
+
 from langchain_core.documents import Document
 from sentence_transformers import SentenceTransformer
 
-# 核心修正：移除所有 'app.' 前缀
 from core.config import EMBEDDING_MODEL_NAME
 from core.db_client import vector_db
+from services.embedding import embedding_model
 
 logger = logging.getLogger(__name__)
 
 
 class KnowledgeBaseService:
-    def __init__(self):
+    def __init__(self, storage_dir: str = "/knowledge_base_docs"):
         self.encoder = None
+        self.storage_dir = storage_dir
+        os.makedirs(self.storage_dir, exist_ok=True)
         self._load_encoder()
 
     def _load_encoder(self):
@@ -23,12 +27,77 @@ class KnowledgeBaseService:
             logger.error(f"加载嵌入模型失败: {e}", exc_info=True)
             raise
 
-    async def add_documents(self, documents: List[Document]):
+    def add_document(self, file_name: str, file_data: bytes) -> str:
+        """Save an uploaded file to the knowledge base."""
+        file_path = os.path.join(self.storage_dir, file_name)
+        with open(file_path, "wb") as f:
+            f.write(file_data)
+        logger.info(f"文档 '{file_name}' 已保存到 '{file_path}'")
+        return file_path
+
+    async def embed_document(self, file_name: str) -> bool:
+        """Embed the specified document and store it in the vector DB."""
+        file_path = os.path.join(self.storage_dir, file_name)
+        if not os.path.isfile(file_path):
+            raise FileNotFoundError(file_path)
+        with open(file_path, "rb") as f:
+            data = f.read()
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            text = data.decode("gbk", errors="ignore")
+        doc = Document(page_content=text, metadata={"source": file_name})
+        embedding = await embedding_model.embed(text)
+        await vector_db.add_documents([doc], [embedding], file_name)
+        return True
+
+    def list_documents(self) -> List[str]:
+        """List file names stored in the knowledge base directory."""
+        return [
+            f
+            for f in os.listdir(self.storage_dir)
+            if os.path.isfile(os.path.join(self.storage_dir, f))
+        ]
+
+    async def list_all_documents(self) -> List[dict] | None:
+        """List all documents stored in the vector database."""
+        try:
+            results = vector_db.collection.get(include=["metadatas"], limit=None)
+            sources = []
+            seen = set()
+            for meta in results.get("metadatas", []):
+                src = meta.get("source")
+                if src and src not in seen:
+                    seen.add(src)
+                    sources.append({"source": src})
+            return sources
+        except Exception as e:
+            logger.error(f"获取文档列表失败: {e}", exc_info=True)
+            return None
+
+    def delete_document(self, file_name: str) -> bool:
+        """Delete a document from storage and vector database."""
+        file_path = os.path.join(self.storage_dir, file_name)
+        if not os.path.exists(file_path):
+            return False
+        os.remove(file_path)
+        vector_db.delete_documents_by_source(file_name)
+        logger.info(f"文档 '{file_name}' 已被删除")
+        return True
+
+    async def delete_documents_by_source(self, source_name: str) -> bool:
+        """Async wrapper to remove documents by source name."""
+        result = self.delete_document(source_name)
+        return result
+
+    async def add_documents(self, documents: List[Document], document_source: str):
         if not documents:
             return
         logger.info(f"准备向知识库添加 {len(documents)} 个文档...")
         try:
-            await vector_db.add_documents(documents)
+            texts = [d.page_content for d in documents]
+            embeddings = await embedding_model.embed_batch(texts)
+            await vector_db.add_documents(documents, embeddings, document_source)
             logger.info(f"成功添加 {len(documents)} 个文档到向量数据库。")
         except Exception as e:
             logger.error(f"添加文档到向量数据库时出错: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- store uploaded knowledge docs under `/knowledge_base_docs`
- compute embeddings and store them via the vector DB
- list and delete docs from storage and vector DB
- implement async similarity search helper in `VectorDBClient`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68637934e43883289e2d4ecd30f0e788