### PR TITLE
Add models volume to backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     env_file: ./modules/backend/.env
     volumes:
       - ./modules/backend/app:/app
+      - ./models:/models
     ports:
       - "8000:8000"
     networks:


### PR DESCRIPTION
## Summary
- mount `./models` to `/models` in the backend container

## Testing
- `docker compose up --build -d` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637934699083289a2bbd3a6a27db56