### PR TITLE
Fix license with ownership

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2025 marspengexdell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- replace placeholders in MIT License with the actual year and owner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863793644a48328ba535c5596945741