### PR TITLE
Fix GRPC client import and models endpoint

### DIFF
--- a/modules/backend/app/services/model_management.py
+++ b/modules/backend/app/services/model_management.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from typing import List, Dict, Optional
-from core.grpc_client import GRPCClient
+from core.inference_service_client import GRPCClient
 from sentence_transformers import SentenceTransformer
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- fix import for `GRPCClient` in `model_management`
- correct variable name in `models` API endpoint

## Testing
- `python -m py_compile modules/backend/app/services/model_management.py modules/backend/app/api/endpoints/models.py`

------
https://chatgpt.com/codex/tasks/task_e_6863baee71748328a6f30da204377f9c