### PR TITLE
Replace chromadb-client with chromadb

### DIFF
--- a/modules/backend/requirements.txt
+++ b/modules/backend/requirements.txt
@@ -13,7 +13,7 @@ protobuf==3.20.3
 sentence-transformers>=2.3.0
 torch>=1.10.0
 numpy
-chromadb-client
+chromadb
 
 # Additional libraries for document processing
 langchain-community


### PR DESCRIPTION
## Summary
- update backend Python requirements to use `chromadb`

## Testing
- `docker compose build backend` *(fails: `docker: command not found`)*
- `pip install -r modules/backend/requirements.txt --no-cache-dir` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863c3d1e8908328b77e41b85dfc850e