### PR TITLE
Fix protobuf version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains a simple knowledge-base system built from several servi
 
 - Docker and Docker Compose installed
 - At least one `.gguf` or `.safetensors` model file under `models/` before starting (embedding model optional)
-- Python package `protobuf` version 6.x
+- Python package `protobuf` version 3.20.3
 
 ### Build and Run
 
@@ -35,9 +35,9 @@ used:
 docker compose build --no-cache backend
 ```
 
-The application depends on `protobuf` 6.x. If your images were built
-with an older major version, rebuild all services without the Docker
-cache to avoid import errors.
+The application depends on `protobuf` 3.20.3. If your images were built
+with a different version, rebuild all services without the Docker cache
+to avoid import errors.
 
 The services will be available on the following ports:
 


### PR DESCRIPTION
## Summary
- update README to reference protobuf 3.20.3

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863c3d3307083288087a210c54ce15f