### PR TITLE
Fix backend gRPC version conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository contains a simple knowledge-base system built from several servi
 - Docker and Docker Compose installed
 - At least one `.gguf` or `.safetensors` model file under `models/` before starting (embedding model optional)
 - Python package `protobuf` version 3.20.3
+- gRPC packages pinned to version 1.48.2
 
 ### Build and Run
 

--- a/modules/backend/requirements.txt
+++ b/modules/backend/requirements.txt
@@ -4,8 +4,8 @@ pydantic==2.7.1
 requests==2.31.0
 sqlmodel==0.0.16
 python-dotenv==1.0.1
-grpcio>=1.58.0
-grpcio-tools>=1.58.0
+grpcio==1.48.2
+grpcio-tools==1.48.2
 websockets==12.0
 pydantic-settings==2.1.0
 python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- pin `grpcio` and `grpcio-tools` in backend requirements to 1.48.2
- note pinned gRPC version in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863eb6455408328968cc24350bb21ab