### PR TITLE
Add protobuf fix for backend image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ docker compose build --no-cache backend
 
 The application depends on `protobuf` 3.20.3. If your images were built
 with a different version, rebuild all services without the Docker cache
-to avoid import errors.
+to avoid import errors. Some packages ship protobuf stubs generated for
+newer versions, which can lead to "Descriptors cannot be created directly"
+runtime errors. The backend Dockerfile now sets the environment variable
+`PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` to fall back to the
+pure-Python protobuf parser and avoid this incompatibility.
 
 The services will be available on the following ports:
 

--- a/modules/backend/Dockerfile
+++ b/modules/backend/Dockerfile
@@ -11,6 +11,10 @@ COPY ./app /app
 COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
+# Work around protobuf runtime incompatibility with some packages by forcing
+# the slower pure-Python implementation
+ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
+
 # 暴露端口
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- fix protobuf runtime issue by enforcing Python implementation in Dockerfile
- document workaround in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6864a9230d348328925381e00b746a48