### PR TITLE
Add protobuf env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ newer versions, which can lead to "Descriptors cannot be created directly"
 runtime errors. The backend Dockerfile now sets the environment variable
 `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` to fall back to the
 pure-Python protobuf parser and avoid this incompatibility.
+This variable is also listed in `modules/backend/.env` so Docker Compose
+exports it automatically when the backend container starts.
 
 The services will be available on the following ports:
 

--- a/modules/backend/.env
+++ b/modules/backend/.env
@@ -10,3 +10,7 @@ BACKEND_CORS_ORIGINS=["http://localhost:8080","http://localhost:8081"]
 
 INFERENCE_SERVER_URL=inference:50051
 VECTOR_DB_URL=http://chromadb:8000
+
+# Use the pure-Python protobuf implementation to avoid runtime errors with
+# packages built against older versions.
+PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python


### PR DESCRIPTION
## Summary
- set `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` in backend `.env`
- document new environment variable in the build instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864c555c9b083289876ba51f98f4449