### PR TITLE
Fix docker-compose contexts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
   # 后端服务: 处理业务逻辑和API
   backend:
     build:
-      context: ./modules/backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: modules/backend/Dockerfile
     container_name: knowledge-base-app-backend
     env_file: ./modules/backend/.env
     volumes:
@@ -51,7 +51,8 @@ services:
   # 推理服务: 运行AI模型
   inference:
     build:
-      context: ./modules/inference
+      context: .
+    dockerfile: modules/inference/Dockerfile
     container_name: knowledge-base-app-inference
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- adjust build contexts for backend and inference services
- keep dockerfiles pointing to modules

## Testing
- `docker compose build --no-cache backend inference` *(fails: docker not installed)*
- `docker compose up` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686536730b54832895684041ea7d8e48