### PR TITLE
Fix dockerfile indentation in inference service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,6 @@ services:
     build:
       context: .
       dockerfile: modules/inference/Dockerfile
-
-    dockerfile: modules/inference/Dockerfile
-
     container_name: knowledge-base-app-inference
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- fix indentation of inference service dockerfile path in `docker-compose.yml`

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686543d54eb08328b4a10b2dcd159f65