### PR TITLE
Fix duplicate imports in models endpoint

### DIFF
--- a/modules/backend/app/api/endpoints/models.py
+++ b/modules/backend/app/api/endpoints/models.py
@@ -1,9 +1,6 @@
 
-from fastapi import APIRouter, HTTPException, UploadFile, File
 from core.grpc_client import grpc_client_manager
 from protos import inference_pb2
-import os
-import shutil
 
 from fastapi import APIRouter, HTTPException, UploadFile, File, Body
 from services.model_service import model_service


### PR DESCRIPTION
## Summary
- deduplicate `fastapi` import in `models.py`
- remove unused `os` and `shutil`

## Testing
- `python3 -m py_compile modules/backend/app/api/endpoints/models.py`

------
https://chatgpt.com/codex/tasks/task_e_68708f86feac8328923972b41a47bd52