### PR TITLE
Refactor load_model endpoint

### DIFF
--- a/modules/backend/app/api/endpoints/models.py
+++ b/modules/backend/app/api/endpoints/models.py
@@ -1,11 +1,7 @@
 
-from fastapi import APIRouter, HTTPException, UploadFile, File
+from fastapi import APIRouter, HTTPException, UploadFile, File, Body
 from core.grpc_client import grpc_client_manager
 from protos import inference_pb2
-import os
-import shutil
-
-from fastapi import APIRouter, HTTPException, UploadFile, File, Body
 from services.model_service import model_service
 
 
@@ -31,15 +27,15 @@ async def load_model(model_name: str, model_type: str = Body("generation")):
     触发加载指定模型，返回是否成功和消息
     """
     try:
+        if model_type.lower() == "embedding":
+            model_enum = inference_pb2.ModelType.EMBEDDING
+        else:
+            model_enum = inference_pb2.ModelType.GENERATION
 
-        success, msg = await grpc_client_manager.switch_model(
-            model_name, inference_pb2.ModelType.GENERATION
-        )
-
-        success, msg = await model_service.switch_model(model_name, model_type)
+        success, loading, msg = await model_service.switch_model(model_name, model_enum)
 
         if not success:
-            if "loading_busy" in (msg or ""):
+            if loading:
                 raise HTTPException(status_code=202, detail="模型正在加载，请稍后再试。")
             raise HTTPException(status_code=500, detail=msg or "切换模型失败")
         return {"success": True, "message": f"Model '{model_name}' 已切换"}


### PR DESCRIPTION
## Summary
- update imports in model endpoint
- remove direct gRPC call and rely on ModelService for switching models

## Testing
- `python -m py_compile modules/backend/app/api/endpoints/models.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68708f8762b88328af377f67eabcb9b7