### PR TITLE
Fix duplicate imports in models endpoint

### DIFF
--- a/modules/backend/app/api/endpoints/models.py
+++ b/modules/backend/app/api/endpoints/models.py
@@ -1,13 +1,6 @@
-
-
 from fastapi import APIRouter, HTTPException, UploadFile, File, Body
 from core.grpc_client import grpc_client_manager
 from protos import inference_pb2
-
-from core.grpc_client import grpc_client_manager
-from protos import inference_pb2
-
-from fastapi import APIRouter, HTTPException, UploadFile, File, Body
 
 from services.model_service import model_service
 


### PR DESCRIPTION
## Summary
- deduplicate `fastapi` and `grpc_client_manager` imports

## Testing
- `python -m py_compile modules/backend/app/api/endpoints/models.py`

------
https://chatgpt.com/codex/tasks/task_e_687099c70ac8832891c3a49dd3addfed