### PR TITLE
Fix documents fetch result

### DIFF
--- a/frontend-admin/src/views/DocumentManagement.vue
+++ b/frontend-admin/src/views/DocumentManagement.vue
@@ -39,8 +39,10 @@ const deleting = ref({});
 const fetchDocuments = async () => {
   loading.value = true; error.value = null;
   try {
-    const response = await axios.get('/api/admin/kb/documents'); 
-    documents.value = response.data;
+    const response = await axios.get('/api/admin/kb/documents');
+    documents.value = response.data.docs || [];
+    // If pagination is implemented later, response.data.total can be used
+    // to update a `total` ref for page controls.
   } catch (err) { error.value = err.response?.data?.detail || err.message; }
   finally { loading.value = false; }
 };


### PR DESCRIPTION
## Summary
- correct document list assignment when fetching docs
- add note for using `total` if pagination is added later

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870a35d0a4c832888ed436aca826bdd