### PR TITLE
Update default Vector DB URL

### DIFF
--- a/modules/backend/app/core/db_client.py
+++ b/modules/backend/app/core/db_client.py
@@ -17,7 +17,7 @@ class VectorDBClient:
 
     def __init__(self):
         # 从环境变量获取ChromaDB的URL
-        db_url_str = os.getenv("VECTOR_DB_URL", "http://vector-db:8000")
+        db_url_str = os.getenv("VECTOR_DB_URL", "http://chromadb:8000")
         logger.info(f"正在连接到向量数据库: {db_url_str}")
 
         try:


### PR DESCRIPTION
## Summary
- use `http://chromadb:8000` as the default `VECTOR_DB_URL`

## Testing
- `python -m py_compile modules/backend/app/core/db_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6874acf1bf1883289c70dce767212362